### PR TITLE
Magicspells compatibility

### DIFF
--- a/CompatNoCheatPlus/src/me/asofold/bpl/cncp/CompatNoCheatPlus.java
+++ b/CompatNoCheatPlus/src/me/asofold/bpl/cncp/CompatNoCheatPlus.java
@@ -19,6 +19,7 @@ import me.asofold.bpl.cncp.hooks.generic.HookBlockPlace;
 import me.asofold.bpl.cncp.hooks.generic.HookEntityDamageByEntity;
 import me.asofold.bpl.cncp.hooks.generic.HookInstaBreak;
 import me.asofold.bpl.cncp.hooks.generic.HookPlayerClass;
+import me.asofold.bpl.cncp.hooks.generic.HookPlayerInteract;
 import me.asofold.bpl.cncp.utils.TickTask2;
 import me.asofold.bpl.cncp.utils.Utils;
 
@@ -194,6 +195,7 @@ public class CompatNoCheatPlus extends JavaPlugin implements Listener {
                 new HookBlockPlace(),
                 new HookInstaBreak(),
                 new HookEntityDamageByEntity(),
+                new HookPlayerInteract()
         }){
             builtinHooks.add(hook);
         }

--- a/CompatNoCheatPlus/src/me/asofold/bpl/cncp/hooks/generic/HookBlockBreak.java
+++ b/CompatNoCheatPlus/src/me/asofold/bpl/cncp/hooks/generic/HookBlockBreak.java
@@ -25,6 +25,8 @@ public class HookBlockBreak extends ClassExemptionHook implements Listener {
 			"ArtificialBlockBreakEvent",
 			// mcMMO
 			"FakeBlockBreakEvent",
+			// MagicSpells
+			"MagicSpellsBlockBreakEvent"
 		}));
 	}
 

--- a/CompatNoCheatPlus/src/me/asofold/bpl/cncp/hooks/generic/HookBlockPlace.java
+++ b/CompatNoCheatPlus/src/me/asofold/bpl/cncp/hooks/generic/HookBlockPlace.java
@@ -22,7 +22,9 @@ public class HookBlockPlace extends ClassExemptionHook implements Listener{
 		super("block-place.");
 		defaultClasses.addAll(Arrays.asList(new String[]{
 			// MachinaCraft
-			"ArtificialBlockPlaceEvent"	
+			"ArtificialBlockPlaceEvent",
+			// MagicSpells
+			"MagicSpellsBlockPlaceEvent"
 		}));
 	}
 

--- a/CompatNoCheatPlus/src/me/asofold/bpl/cncp/hooks/generic/HookEntityDamageByEntity.java
+++ b/CompatNoCheatPlus/src/me/asofold/bpl/cncp/hooks/generic/HookEntityDamageByEntity.java
@@ -20,7 +20,9 @@ public class HookEntityDamageByEntity extends ClassExemptionHook implements
 		super("entity-damage-by-entity.");
 		defaultClasses.addAll(Arrays.asList(new String[] {
 		// CrackShot
-		"WeaponDamageEntityEvent", }));
+		"WeaponDamageEntityEvent",
+		// MagicSpells
+		"MagicSpellsEntityDamageByEntityEvent" }));
 	}
 
 	@Override

--- a/CompatNoCheatPlus/src/me/asofold/bpl/cncp/hooks/generic/HookPlayerInteract.java
+++ b/CompatNoCheatPlus/src/me/asofold/bpl/cncp/hooks/generic/HookPlayerInteract.java
@@ -1,0 +1,58 @@
+package me.asofold.bpl.cncp.hooks.generic;
+
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import me.asofold.bpl.cncp.config.compatlayer.CompatConfig;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.util.Arrays;
+
+/**
+ * Wrap player interact events to exempt players from checks by comparison of event class names.
+ * Uses mc_dev's format for exemption based upon class names.
+ *
+ */
+public class HookPlayerInteract extends ClassExemptionHook implements Listener{
+
+	public HookPlayerInteract() {
+		super("player-interact.");
+		defaultClasses.addAll(Arrays.asList(new String[]{
+			// MagicSpells
+			"MagicSpellsPlayerInteractEvent"
+		}));
+	}
+
+	@Override
+	public String getHookName() {
+		return "Interact(default)";
+	}
+
+	@Override
+	public String getHookVersion() {
+		return "1.0";
+	}
+	
+	@Override
+	public Listener[] getListeners() {
+		return new Listener[]{this};
+	}
+	
+	@Override
+	public void applyConfig(CompatConfig cfg, String prefix) {
+		super.applyConfig(cfg, prefix);
+		if (classes.isEmpty()) enabled = false;
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	final void onPlayerInteractLowest(final PlayerInteractEvent event){
+		checkExempt(event.getPlayer(), event.getClass(), CheckType.BLOCKINTERACT);
+	}
+	
+	@EventHandler(priority = EventPriority.MONITOR)
+	final void onPlayerInteractMonitor(final PlayerInteractEvent event){
+		checkUnexempt(event.getPlayer(), event.getClass(), CheckType.BLOCKINTERACT);
+	}
+
+}


### PR DESCRIPTION
This should be a fairly safe approach to making MagicSpells and NCPC get along better. I added MagicSpells's wrapper event classes to the defaults in the class based exemptions and then added an additional hook for exempting player interact events based upon class.

It is worth noting that this will not help Nisovin's version of Magicspells very much as I don't believe it uses event wrappers.